### PR TITLE
Add Flask app for stock open price viewer with chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,64 @@
+import os
+from flask import Flask, render_template, request, jsonify
+import pandas as pd
+import yfinance as yf
+import openai
+
+app = Flask(__name__)
+
+# store latest open price data for chat context
+latest_data = {}
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    global latest_data
+    data = None
+    symbol = ""
+    start = ""
+    end = ""
+    if request.method == "POST":
+        symbol = request.form.get("symbol", "").strip()
+        start = request.form.get("start", "").strip()
+        end = request.form.get("end", "").strip()
+        if symbol and start and end:
+            ticker = yf.Ticker(symbol)
+            df = ticker.history(start=start, end=end)
+            df = df.reset_index()
+            data = df[["Date", "Open"]].to_dict(orient="records")
+            latest_data = {
+                row["Date"].strftime("%Y-%m-%d"): row["Open"] for row in data
+            }
+    return render_template("index.html", data=data, symbol=symbol, start=start, end=end)
+
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    user_message = request.json.get("message", "")
+    if not user_message:
+        return jsonify({"reply": "請輸入訊息"}), 400
+
+    # construct system prompt with open price data
+    context_lines = [f"{date}: {price}" for date, price in latest_data.items()]
+    system_prompt = (
+        "你是一個股票助理，能夠根據以下開盤價回答問題或提供解釋：\n"
+        + "\n".join(context_lines)
+    )
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message},
+            ],
+        )
+        reply = response.choices[0].message["content"]
+    except Exception as e:
+        reply = f"Error: {e}"
+    return jsonify({"reply": reply})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+pandas
+yfinance
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>開盤價查詢</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        #chat-box {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            width: 300px;
+            max-height: 400px;
+            border: 1px solid #ccc;
+            background: #fff;
+            display: none;
+            flex-direction: column;
+        }
+        #chat-header {
+            background: #eee;
+            padding: 5px;
+            cursor: pointer;
+        }
+        #chat-messages {
+            padding: 5px;
+            overflow-y: auto;
+            flex: 1;
+        }
+        #chat-input {
+            display: flex;
+        }
+        #chat-input input {
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+    <h1>查詢開盤價</h1>
+    <form method="post">
+        股票代碼: <input type="text" name="symbol" value="{{ symbol }}" required>
+        開始日期: <input type="date" name="start" value="{{ start }}" required>
+        結束日期: <input type="date" name="end" value="{{ end }}" required>
+        <button type="submit">查詢</button>
+    </form>
+    {% if data %}
+    <canvas id="chart" width="600" height="400"></canvas>
+    <script>
+        const data = {{ data|tojson }};
+        const labels = data.map(d => d.Date);
+        const opens = data.map(d => d.Open);
+        const ctx = document.getElementById('chart').getContext('2d');
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Open',
+                    data: opens,
+                    borderColor: 'blue',
+                    fill: false
+                }]
+            },
+            options: {
+                scales: {
+                    x: { display: true },
+                    y: { display: true }
+                },
+                interaction: { mode: 'index', intersect: false }
+            }
+        });
+    </script>
+    {% endif %}
+
+    <div id="chat-box">
+        <div id="chat-header">對話</div>
+        <div id="chat-messages"></div>
+        <div id="chat-input">
+            <input type="text" id="chat-text" placeholder="輸入訊息">
+            <button id="send-btn">送出</button>
+        </div>
+    </div>
+    <script>
+        const header = document.getElementById('chat-header');
+        const box = document.getElementById('chat-box');
+        const messages = document.getElementById('chat-messages');
+        const sendBtn = document.getElementById('send-btn');
+        const text = document.getElementById('chat-text');
+
+        header.addEventListener('click', () => {
+            box.style.display = box.style.display === 'none' ? 'flex' : 'none';
+        });
+
+        function appendMsg(content, cls) {
+            const div = document.createElement('div');
+            div.textContent = content;
+            div.className = cls;
+            messages.appendChild(div);
+            messages.scrollTop = messages.scrollHeight;
+        }
+
+        sendBtn.addEventListener('click', async () => {
+            const msg = text.value.trim();
+            if (!msg) return;
+            appendMsg('我: ' + msg, 'user');
+            text.value = '';
+            const res = await fetch('/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: msg })
+            });
+            if (res.ok) {
+                const data = await res.json();
+                appendMsg('助理: ' + data.reply, 'bot');
+            } else {
+                appendMsg('Error', 'bot');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app to query open price history
- render interactive chart with Chart.js
- include chat widget that uses OpenAI API
- document dependencies in requirements.txt

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68726d027b188329bf02c7aa81b3bea7