### PR TITLE
Add beginner Python notebooks with Colab links

### DIFF
--- a/Python-basics/1_basic_output.ipynb
+++ b/Python-basics/1_basic_output.ipynb
@@ -1,0 +1,57 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Python 基礎 1: 輸出與變數"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/1_basic_output.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 印出訊息\nprint('Hello, world!')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 使用變數\nname = '小明'\nprint('你好,', name)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 練習題\n1. 嘗試建立兩個變數，並印出它們的和。"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    },
+    "colab": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/Python-basics/2_conditions_loops.ipynb
+++ b/Python-basics/2_conditions_loops.ipynb
@@ -1,0 +1,57 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Python 基礎 2: 條件與迴圈"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/2_conditions_loops.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# if 判斷\nx = 5\nif x > 3:\n    print('x 大於 3')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# for 迴圈\nfor i in range(3):\n    print('迴圈次數', i)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 練習題\n1. 嘗試寫一個迴圈，計算 1 到 10 的總和。"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    },
+    "colab": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/Python-basics/3_functions.ipynb
+++ b/Python-basics/3_functions.ipynb
@@ -1,0 +1,57 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Python 基礎 3: 函式"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/3_functions.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 定義一個函式\ndef greet(name):\n    print(f'哈囉, {name}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "greet('小美')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 練習題\n1. 寫一個函式，回傳兩數相乘的結果。"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    },
+    "colab": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/Python-basics/4_data_structures.ipynb
+++ b/Python-basics/4_data_structures.ipynb
@@ -1,0 +1,57 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Python 基礎 4: List 與 Dictionary"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/4_data_structures.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 建立 list\nfruits = ['蘋果', '香蕉', '橘子']\nfor f in fruits:\n    print(f)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# 建立 dictionary\nstudent = {'name': '小華', 'age': 16}\nprint(student['name'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 練習題\n1. 請新增一個水果到 fruits 並印出全部內容。"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    },
+    "colab": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/Python-basics/README.md
+++ b/Python-basics/README.md
@@ -1,0 +1,19 @@
+# Python 基礎課程
+
+本資料夾提供四個設計給初學者的 Jupyter Notebook，
+可直接於 [Google Colab](https://colab.research.google.com/) 執行。
+
+## 如何在 Colab 開啟
+瀏覽 GitHub 時，點擊下表中的 `Open in Colab` 按鈕即可在雲端開啟。 
+若你是從自己的 Fork 存取，請將連結中的 `YOUR_GITHUB_USERNAME` 
+改成你的 GitHub 帳號。
+
+## 課程內容
+| Notebook | 內容 | 連結 |
+| --- | --- | --- |
+| `1_basic_output.ipynb` | 認識 `print` 與變數使用 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/1_basic_output.ipynb) |
+| `2_conditions_loops.ipynb` | 學習 `if` 判斷式與 `for` 迴圈 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/2_conditions_loops.ipynb) |
+| `3_functions.ipynb` | 介紹函式的定義與呼叫方式 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/3_functions.ipynb) |
+| `4_data_structures.ipynb` | 說明 List 及 Dictionary 的基本操作 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_GITHUB_USERNAME/Github-Codex/blob/main/Python-basics/4_data_structures.ipynb) |
+
+每個 Notebook 最後皆附有練習題，歡迎嘗試完成。

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ Github-Codex is a small Flask web application that retrieves stock opening price
    python app.py
    ```
 4. Open your browser at `http://localhost:5000`.
+
+## Python 基礎教學
+本專案新增一個 `Python-basics` 資料夾，內含四個適合初學者的 Notebook。
+每份 Notebook 都在開頭放置了 “Open in Colab” 按鈕，
+在資料夾的 `README` 也提供了所有連結，方便直接於雲端操作。


### PR DESCRIPTION
## Summary
- add Open in Colab badge for each beginner notebook
- update the tutorial README with buttons linking to Google Colab
- mention the Colab buttons in the main README
- refine README notes on accessing the notebooks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872fbe6d030832980c6a63042641ae7